### PR TITLE
missing new line in bulk send join in order to fulfill bulk commit reqs

### DIFF
--- a/client.go
+++ b/client.go
@@ -236,6 +236,8 @@ func (t *Client) sendAll(evts []*StoreEvent, h errorHandler) (int, error) {
 	}
 
 	req := bytes.Join(bulk, []byte("\n"))
+	req = append(req, '\n') 
+
 	if err := t.sendBulk(req); err != nil {
 		log.Printf("bulk send failed with error: %v", err)
 		if ferr := onFail(evts, err); ferr != nil {


### PR DESCRIPTION
Without the ending new line character, bulk commit will only send first events and server will ignore last event. If only one event is sent, then server ignores it completely. This fulfills requirements of bulk commit on server side (what it's expecting anyway).